### PR TITLE
Fix link in SUPPORT.md

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -14,5 +14,5 @@ For bugs and feature requests, open an issue in the appropriate repository.
 ## Additional Resources
 
 - **Documentation**: [docs.monad.xyz](https://docs.monad.xyz)
-- [**Community Suggested Resources**](https://docs.monad.xyz/category/evm-resources)
+- [**Community Suggested Resources**](https://docs.monad.xyz/guides/evm-resources)
 <!-- TODO: Add Youtube Channel -->


### PR DESCRIPTION
Updated the "Community Suggested Resources" link to point to the more specific /guides/evm-resources instead of the general /category/evm-resources page.